### PR TITLE
fix: use URLSearchParams to encode tag filters correctly

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -22,7 +22,10 @@ export default function Home() {
 
   const handleShowIssues = () => {
     if (selectedLanguages.length > 0) {
-      const tags = selectedLanguages.map((lang) => `tag=${lang}`).join("&");
+      const tags = new URLSearchParams();
+      selectedLanguages.forEach((lang) => {
+        tags.append("tag", lang);
+      });
       redirect(`/issues?${tags}`);
     }
   };


### PR DESCRIPTION
## Descrição

Substitui a construção manual da query string por URLSearchParams, que faz o encode automático de caracteres especiais como "#". Isso corrige o problema com filtros como "C#" não retornando resultados.

## Issues Relacionadas

- Fecha #12 

## Tipo de Alteração

- [x] Correção de bug (alteração ininterrupta que corrige um problema)
- [ ] Novo recurso (alteração ininterrupta que adiciona funcionalidade)
- [ ] Alteração de última hora (correção ou recurso que faria com que a funcionalidade existente não funcionasse como esperado)
- [ ] Documentação

## Checklist

- [x] Meu código segue as diretrizes de estilo deste projeto.
- [x] Eu realizei uma auto-revisão do meu próprio código.
- [x] Eu comentei meu código, particularmente em áreas de difícil compreensão.
- [x] Eu fiz as alterações correspondentes na documentação.
- [x] Meus Pull Requests estão direcionados para a branch `main`.